### PR TITLE
Allow Operator to wait until training job finishes

### DIFF
--- a/airflow/contrib/hooks/sagemaker_hook.py
+++ b/airflow/contrib/hooks/sagemaker_hook.py
@@ -36,7 +36,7 @@ class SageMakerHook(AwsHook):
                  sagemaker_conn_id=None,
                  use_db_config=False,
                  region_name=None,
-                 check_interval=2,
+                 check_interval=5,
                  max_ingestion_time=None,
                  *args, **kwargs):
         super(SageMakerHook, self).__init__(*args, **kwargs)
@@ -164,7 +164,7 @@ class SageMakerHook(AwsHook):
         return self.conn.list_hyper_parameter_tuning_job(
             NameContains=name_contains, StatusEquals=status_equals)
 
-    def create_training_job(self, training_job_config, wait=False):
+    def create_training_job(self, training_job_config, wait=True):
         """
         Create a training job
         :param training_job_config: the config for training

--- a/airflow/contrib/hooks/sagemaker_hook.py
+++ b/airflow/contrib/hooks/sagemaker_hook.py
@@ -237,14 +237,3 @@ class SageMakerHook(AwsHook):
         return self.conn\
             .describe_hyper_parameter_tuning_job(
                 HyperParameterTuningJobName=tuning_job_name)
-
-    def describe_model(self, tuning_job_name):
-        """
-        :param tuning_job_name: the name of the training job
-        :type tuning_job_name: string
-        Return the tuning job info associated with the current job_name
-        :return: A dict contains all the tuning job info
-        """
-        return self.conn\
-            .describe_hyper_parameter_tuning_job(
-                HyperParameterTuningJobName=tuning_job_name)

--- a/airflow/contrib/operators/sagemaker_create_training_job_operator.py
+++ b/airflow/contrib/operators/sagemaker_create_training_job_operator.py
@@ -46,6 +46,15 @@ class SageMakerCreateTrainingJobOperator(BaseOperator):
        :type use_db_config: bool
        :param aws_conn_id: The AWS connection ID to use.
        :type aws_conn_id: string
+       :param wait: if the program should keep running until job finishes
+       :type wait: bool
+       :param check_interval: if wait is set to be true, this is the time interval
+       which the operator will check the status of the training job
+       :type check_interval: int
+       :param max_ingestion_time: if wait is set to be true, the operator will fail
+       if the training job hasn't finish within the max_ingestion_time
+       (Caution: be careful to set this parameters because training can take very long)
+       :type max_ingestion_time: int
 
        **Example**:
            The following operator would start a training job when executed
@@ -71,6 +80,9 @@ class SageMakerCreateTrainingJobOperator(BaseOperator):
                  region_name=None,
                  sagemaker_conn_id=None,
                  use_db_config=False,
+                 wait=False,
+                 check_interval=2,
+                 max_ingestion_time=None,
                  *args, **kwargs):
         super(SageMakerCreateTrainingJobOperator, self).__init__(*args, **kwargs)
 
@@ -78,18 +90,25 @@ class SageMakerCreateTrainingJobOperator(BaseOperator):
         self.training_job_config = training_job_config
         self.use_db_config = use_db_config
         self.region_name = region_name
+        self.wait = wait
+        self.check_interval = check_interval
+        self.max_ingestion_time = max_ingestion_time
 
     def execute(self, context):
         sagemaker = SageMakerHook(
             sagemaker_conn_id=self.sagemaker_conn_id,
             use_db_config=self.use_db_config,
-            region_name=self.region_name)
+            region_name=self.region_name,
+            check_interval=self.check_interval,
+            max_ingestion_time=self.max_ingestion_time
+            )
 
         self.log.info(
             "Creating SageMaker Training Job %s."
             % self.training_job_config['TrainingJobName']
         )
-        response = sagemaker.create_training_job(self.training_job_config)
+        response = sagemaker.create_training_job(self.training_job_config,
+                                                 wait=self.wait)
         if not response['ResponseMetadata']['HTTPStatusCode'] \
            == 200:
             raise AirflowException(

--- a/airflow/contrib/operators/sagemaker_create_training_job_operator.py
+++ b/airflow/contrib/operators/sagemaker_create_training_job_operator.py
@@ -101,7 +101,7 @@ class SageMakerCreateTrainingJobOperator(BaseOperator):
             region_name=self.region_name,
             check_interval=self.check_interval,
             max_ingestion_time=self.max_ingestion_time
-            )
+        )
 
         self.log.info(
             "Creating SageMaker Training Job %s."

--- a/airflow/contrib/operators/sagemaker_create_training_job_operator.py
+++ b/airflow/contrib/operators/sagemaker_create_training_job_operator.py
@@ -80,7 +80,7 @@ class SageMakerCreateTrainingJobOperator(BaseOperator):
                  region_name=None,
                  sagemaker_conn_id=None,
                  use_db_config=False,
-                 wait=False,
+                 wait=True,
                  check_interval=2,
                  max_ingestion_time=None,
                  *args, **kwargs):

--- a/airflow/contrib/operators/sagemaker_create_training_job_operator.py
+++ b/airflow/contrib/operators/sagemaker_create_training_job_operator.py
@@ -81,7 +81,7 @@ class SageMakerCreateTrainingJobOperator(BaseOperator):
                  sagemaker_conn_id=None,
                  use_db_config=False,
                  wait=True,
-                 check_interval=2,
+                 check_interval=5,
                  max_ingestion_time=None,
                  *args, **kwargs):
         super(SageMakerCreateTrainingJobOperator, self).__init__(*args, **kwargs)

--- a/tests/contrib/hooks/test_sagemaker_hook.py
+++ b/tests/contrib/hooks/test_sagemaker_hook.py
@@ -162,6 +162,38 @@ db_config = {
     ]
 }
 
+DESCRIBE_TRAINING_INPROGRESS_RETURN = {
+    'TrainingJobStatus': 'InProgress',
+    'ResponseMetadata': {
+        'HTTPStatusCode': 200,
+    }
+}
+DESCRIBE_TRAINING_COMPELETED_RETURN = {
+    'TrainingJobStatus': 'Compeleted',
+    'ResponseMetadata': {
+        'HTTPStatusCode': 200,
+    }
+}
+DESCRIBE_TRAINING_FAILED_RETURN = {
+    'TrainingJobStatus': 'Failed',
+    'ResponseMetadata': {
+        'HTTPStatusCode': 200,
+    },
+    'FailureReason': 'Unknown'
+}
+DESCRIBE_TRAINING_STOPPING_RETURN = {
+    'TrainingJobStatus': 'Stopping',
+    'ResponseMetadata': {
+        'HTTPStatusCode': 200,
+    }
+}
+DESCRIBE_TRAINING_STOPPED_RETURN = {
+    'TrainingJobStatus': 'Stopped',
+    'ResponseMetadata': {
+        'HTTPStatusCode': 200,
+    }
+}
+
 
 class TestSageMakerHook(unittest.TestCase):
 
@@ -278,6 +310,46 @@ class TestSageMakerHook(unittest.TestCase):
         updated_config.update(db_config)
         mock_session.create_training_job.assert_called_once_with(**updated_config)
         self.assertEqual(response, test_arn_return)
+
+    @mock.patch.object(SageMakerHook, 'check_valid_training_input')
+    @mock.patch.object(SageMakerHook, 'get_conn')
+    def test_training_ends_with_wait_on(self, mock_client, mock_check_training):
+        mock_check_training.return_value = True
+        mock_session = mock.Mock()
+        attrs = {'create_training_job.return_value':
+                 test_arn_return,
+                 'describe_training_job.side_effect':
+                     [DESCRIBE_TRAINING_INPROGRESS_RETURN,
+                      DESCRIBE_TRAINING_STOPPING_RETURN,
+                      DESCRIBE_TRAINING_STOPPED_RETURN,
+                      DESCRIBE_TRAINING_COMPELETED_RETURN]
+                 }
+        mock_session.configure_mock(**attrs)
+        mock_client.return_value = mock_session
+        hook = SageMakerHook(sagemaker_conn_id='sagemaker_test_conn_id_1')
+        hook.create_training_job(create_training_params, wait=True)
+        self.assertEqual(mock_session.describe_training_job.call_count, 4)
+
+    @mock.patch.object(SageMakerHook, 'check_valid_training_input')
+    @mock.patch.object(SageMakerHook, 'get_conn')
+    def test_training_throws_error_when_failed_with_wait_on(
+            self, mock_client, mock_check_training):
+        mock_check_training.return_value = True
+        mock_session = mock.Mock()
+        attrs = {'create_training_job.return_value':
+                 test_arn_return,
+                 'describe_training_job.side_effect':
+                     [DESCRIBE_TRAINING_INPROGRESS_RETURN,
+                      DESCRIBE_TRAINING_STOPPING_RETURN,
+                      DESCRIBE_TRAINING_STOPPED_RETURN,
+                      DESCRIBE_TRAINING_FAILED_RETURN]
+                 }
+        mock_session.configure_mock(**attrs)
+        mock_client.return_value = mock_session
+        hook = SageMakerHook(sagemaker_conn_id='sagemaker_test_conn_id_1')
+        self.assertRaises(AirflowException, hook.create_training_job,
+                          create_training_params, wait=True)
+        self.assertEqual(mock_session.describe_training_job.call_count, 4)
 
     @mock.patch.object(SageMakerHook, 'check_valid_tuning_input')
     @mock.patch.object(SageMakerHook, 'get_conn')

--- a/tests/contrib/hooks/test_sagemaker_hook.py
+++ b/tests/contrib/hooks/test_sagemaker_hook.py
@@ -290,7 +290,7 @@ class TestSageMakerHook(unittest.TestCase):
         mock_session.configure_mock(**attrs)
         mock_client.return_value = mock_session
         hook = SageMakerHook(sagemaker_conn_id='sagemaker_test_conn_id')
-        response = hook.create_training_job(create_training_params)
+        response = hook.create_training_job(create_training_params, wait=False)
         mock_session.create_training_job.assert_called_once_with(**create_training_params)
         self.assertEqual(response, test_arn_return)
 
@@ -305,7 +305,8 @@ class TestSageMakerHook(unittest.TestCase):
         mock_client.return_value = mock_session
         hook_use_db_config = SageMakerHook(sagemaker_conn_id='sagemaker_test_conn_id',
                                            use_db_config=True)
-        response = hook_use_db_config.create_training_job(create_training_params)
+        response = hook_use_db_config.create_training_job(create_training_params,
+                                                          wait=False)
         updated_config = copy.deepcopy(create_training_params)
         updated_config.update(db_config)
         mock_session.create_training_job.assert_called_once_with(**updated_config)

--- a/tests/contrib/operators/test_sagemaker_create_training_job_operator.py
+++ b/tests/contrib/operators/test_sagemaker_create_training_job_operator.py
@@ -95,7 +95,9 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
             sagemaker_conn_id='sagemaker_test_id',
             training_job_config=create_training_params,
             region_name='us-west-2',
-            use_db_config=True
+            use_db_config=True,
+            wait=True,
+            check_interval=5
         )
 
     @mock.patch.object(SageMakerHook, 'get_conn')
@@ -110,7 +112,10 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
         hook_init.assert_called_once_with(
             sagemaker_conn_id='sagemaker_test_id',
             region_name='us-west-2',
-            use_db_config=True)
+            use_db_config=True,
+            check_interval=5,
+            max_ingestion_time=None
+        )
 
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'create_training_job')
@@ -119,7 +124,9 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
                                       "ResponseMetadata":
                                           {"HTTPStatusCode": 200}}
         self.sagemaker.execute(None)
-        mock_training.assert_called_once_with(create_training_params)
+        mock_training.assert_called_once_with(create_training_params,
+                                              wait=True
+                                              )
 
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'create_training_job')

--- a/tests/contrib/operators/test_sagemaker_create_training_job_operator.py
+++ b/tests/contrib/operators/test_sagemaker_create_training_job_operator.py
@@ -96,7 +96,7 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
             training_job_config=create_training_params,
             region_name='us-west-2',
             use_db_config=True,
-            wait=True,
+            wait=False,
             check_interval=5
         )
 
@@ -125,7 +125,7 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
                                           {"HTTPStatusCode": 200}}
         self.sagemaker.execute(None)
         mock_training.assert_called_once_with(create_training_params,
-                                              wait=True
+                                              wait=False
                                               )
 
     @mock.patch.object(SageMakerHook, 'get_conn')


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
